### PR TITLE
fix spring bug

### DIFF
--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -35,7 +35,7 @@ module Apipie
 
       def finish
         record_params, record_examples = false, false
-        case Apipie.configuration.record
+        case ENV['APIPIE_RECORD']
         when "params"   then record_params = true
         when "examples" then record_examples = true
         when "all"      then record_params = true, record_examples = true


### PR DESCRIPTION
when run test, spring will cache the Apipie.configuration, if run test first time with APIPIE_RECORD=examples then every time apipie will record sample respone to file